### PR TITLE
feat: profiles domain

### DIFF
--- a/.github/.workflows/tests.yaml
+++ b/.github/.workflows/tests.yaml
@@ -1,0 +1,31 @@
+on:
+  push:
+
+jobs:
+  unit-testing:
+    name: unit-testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Config
+        user: actions/checkout@v4
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.4.0
+
+      - name: Dependencies cache
+        uses: actions/cache@v4
+        id: dependencies-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        if: ${{ steps.dependencies-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: npm ci --ignore-scripts
+
+      - name: Run tests
+        shell: bash
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "src/(.*)": "<rootDir>/$1"
+    }
   }
 }

--- a/src/modules/measurements/domain/ports/measurements.publisher.ts
+++ b/src/modules/measurements/domain/ports/measurements.publisher.ts
@@ -1,5 +1,6 @@
+import { Profile } from 'src/modules/profiles/domain/entities/profile.domain'
 import { MeasurementWarning } from '../entities/measurement-warning.domain'
 
 export interface IMeasurementsPublisher {
-  notifyWarning(warning: MeasurementWarning): Promise<void>
+  notifyWarning(profile: Profile, warning: MeasurementWarning): Promise<void>
 }

--- a/src/modules/measurements/domain/ports/measurements.repository.ts
+++ b/src/modules/measurements/domain/ports/measurements.repository.ts
@@ -1,11 +1,12 @@
+import { Profile } from 'src/modules/profiles/domain/entities/profile.domain'
 import { Heartbeat } from '../entities/heartbeat.domain'
 import { MeasurementWarning } from '../entities/measurement-warning.domain'
 
 export interface IMeasurementsRepository {
-  register(heartbeat: Heartbeat): Promise<string>
-  findIrregularsInLast(measurementsCount: number): Promise<Heartbeat[]>
-  findIrregularsSince(warningStart: Date): Promise<Heartbeat[]>
-  registerWarning(measurementWarning: MeasurementWarning): Promise<void>
-  findActiveWarning(): Promise<MeasurementWarning | undefined>
-  finishWarning(measurementWarning: MeasurementWarning): Promise<void>
+  register(profile: Profile, heartbeat: Heartbeat): Promise<string>
+  findIrregularsInLast(profile: Profile, measurementsCount: number): Promise<Heartbeat[]>
+  findIrregularsSince(profile: Profile, warningStart: Date): Promise<Heartbeat[]>
+  registerWarning(profile: Profile, measurementWarning: MeasurementWarning): Promise<void>
+  findActiveWarning(profile: Profile): Promise<MeasurementWarning | undefined>
+  finishWarning(profile: Profile, measurementWarning: MeasurementWarning): Promise<void>
 }

--- a/src/modules/measurements/domain/ports/measurements.service.ts
+++ b/src/modules/measurements/domain/ports/measurements.service.ts
@@ -1,5 +1,6 @@
+import { Profile } from 'src/modules/profiles/domain/entities/profile.domain'
 import { Heartbeat } from '../entities/heartbeat.domain'
 
 export interface IMeasurementsService {
-  checkCondition(heartbeat: Heartbeat): Promise<void>
+  checkCondition(profile: Profile, heartbeat: Heartbeat): Promise<void>
 }

--- a/src/modules/measurements/domain/services/tests/measurements.spec.ts
+++ b/src/modules/measurements/domain/services/tests/measurements.spec.ts
@@ -4,31 +4,33 @@ import { MeasurementWarning } from '../../entities/measurement-warning.domain'
 import { IMeasurementsRepository } from '../../ports/measurements.repository'
 import { MeasurementsService } from '../measurements'
 import { IMeasurementsPublisher } from '../../ports/measurements.publisher'
+import { Profile } from 'src/modules/profiles/domain/entities/profile.domain'
 
 describe('measurements', () => {
   const BASELINE_RATE = 0.18504999999999913
 
   class RepositoryMock implements IMeasurementsRepository {
-    register = jest.fn<Promise<string>, [heartbeat: Heartbeat]>()
-    findIrregularsInLast = jest.fn<Promise<Heartbeat[]>, [measurementsCount: number]>(
+    register = jest.fn<Promise<string>, [profile: Profile, heartbeat: Heartbeat]>()
+    findIrregularsInLast = jest.fn<Promise<Heartbeat[]>, [profile: Profile, measurementsCount: number]>(
       () => Promise.resolve([])
     )
-    findIrregularsSince = jest.fn<Promise<Heartbeat[]>, [warningStart: Date]>(
+    findIrregularsSince = jest.fn<Promise<Heartbeat[]>, [profile: Profile, warningStart: Date]>(
       () => Promise.resolve([])
     )
-    registerWarning = jest.fn<Promise<void>, [measurementWarning: MeasurementWarning]>()
-    findActiveWarning = jest.fn<Promise<MeasurementWarning | undefined>, []>()
-    finishWarning = jest.fn<Promise<void>, [measurementWarning: MeasurementWarning]>()
+    registerWarning = jest.fn<Promise<void>, [profile: Profile, measurementWarning: MeasurementWarning]>()
+    findActiveWarning = jest.fn<Promise<MeasurementWarning | undefined>, [profile: Profile]>()
+    finishWarning = jest.fn<Promise<void>, [profile: Profile, measurementWarning: MeasurementWarning]>()
   }
 
   class PublisherMock implements IMeasurementsPublisher {
-    notifyWarning = jest.fn<Promise<void>, [warning: MeasurementWarning]>()
+    notifyWarning = jest.fn<Promise<void>, [profile: Profile, warning: MeasurementWarning]>()
   }
 
   const repositoryMock = new RepositoryMock()
   const publisherMock = new PublisherMock()
   const service = new MeasurementsService(repositoryMock, publisherMock)
 
+  const profile = new Profile('testing', randomUUID())
   const regularHeartbeat = new Heartbeat(BASELINE_RATE, 15000, new Date())
   const irregularHeartbeat = new Heartbeat(BASELINE_RATE - (BASELINE_RATE * 0.2), 15000, new Date())
 
@@ -36,20 +38,20 @@ describe('measurements', () => {
 
   describe('checkCondition()', () => {
     it('should register a new heartbeat measurement', async () => {
-      await service.checkCondition(regularHeartbeat)
+      await service.checkCondition(profile, regularHeartbeat)
 
       expect(repositoryMock.register).toHaveBeenCalledTimes(1)
     })
 
     it('should not retrieve the last measurements if the current measurement is regular and does not have an active warning', async () => {
-      await service.checkCondition(regularHeartbeat)
+      await service.checkCondition(profile, regularHeartbeat)
 
       expect(repositoryMock.findActiveWarning).toHaveBeenCalledTimes(1)
       expect(repositoryMock.findIrregularsInLast).not.toHaveBeenCalled()
     })
 
     it('should retrieve the last measurements if the current measurement is irregular', async () => {
-      await service.checkCondition(irregularHeartbeat)
+      await service.checkCondition(profile, irregularHeartbeat)
 
       expect(repositoryMock.findIrregularsInLast).toHaveBeenCalledTimes(1)
     })
@@ -63,7 +65,7 @@ describe('measurements', () => {
         ]
       )
 
-      await service.checkCondition(irregularHeartbeat)
+      await service.checkCondition(profile, irregularHeartbeat)
 
       expect(repositoryMock.findIrregularsInLast).toHaveBeenCalledTimes(1)
       expect(repositoryMock.registerWarning).not.toHaveBeenCalled()
@@ -80,7 +82,7 @@ describe('measurements', () => {
         ]
       )
 
-      await service.checkCondition(irregularHeartbeat)
+      await service.checkCondition(profile, irregularHeartbeat)
 
       expect(repositoryMock.findIrregularsInLast).toHaveBeenCalledTimes(1)
       expect(repositoryMock.registerWarning).toHaveBeenCalledTimes(1)
@@ -97,7 +99,7 @@ describe('measurements', () => {
         ]
       )
 
-      await service.checkCondition(irregularHeartbeat)
+      await service.checkCondition(profile, irregularHeartbeat)
 
       expect(repositoryMock.findIrregularsInLast).toHaveBeenCalledTimes(1)
       expect(repositoryMock.registerWarning).toHaveBeenCalledTimes(1)
@@ -108,18 +110,18 @@ describe('measurements', () => {
       const activeWarning = new MeasurementWarning(randomUUID(), new Date())
       repositoryMock.findActiveWarning.mockResolvedValueOnce(activeWarning)
 
-      await service.checkCondition(regularHeartbeat)
+      await service.checkCondition(profile, regularHeartbeat)
 
       expect(repositoryMock.findActiveWarning).toHaveBeenCalledTimes(1)
       expect(repositoryMock.registerWarning).not.toHaveBeenCalled()
-      expect(repositoryMock.findIrregularsSince).toHaveBeenCalledWith(activeWarning.getStartedAt())
+      expect(repositoryMock.findIrregularsSince).toHaveBeenCalledWith(profile, activeWarning.getStartedAt())
     })
 
     it('should not finish the warning if there is any irregular behaviour in the sixty measurements since the warning start', async () => {
       repositoryMock.findActiveWarning.mockResolvedValueOnce(new MeasurementWarning(randomUUID(), new Date()))
       repositoryMock.findIrregularsSince.mockResolvedValueOnce([irregularHeartbeat])
 
-      await service.checkCondition(regularHeartbeat)
+      await service.checkCondition(profile, regularHeartbeat)
 
       expect(repositoryMock.findActiveWarning).toHaveBeenCalledTimes(1)
       expect(repositoryMock.findIrregularsSince).toHaveBeenCalledTimes(1)
@@ -134,11 +136,12 @@ describe('measurements', () => {
       repositoryMock.register.mockResolvedValueOnce(heartbeatEndId)
       repositoryMock.findActiveWarning.mockResolvedValueOnce(new MeasurementWarning(heartbeatStartId, warningStartedAt))
 
-      await service.checkCondition(regularHeartbeat)
+      await service.checkCondition(profile, regularHeartbeat)
 
       expect(repositoryMock.findActiveWarning).toHaveBeenCalledTimes(1)
       expect(repositoryMock.findIrregularsSince).toHaveBeenCalledTimes(1)
       expect(repositoryMock.finishWarning).toHaveBeenCalledWith(
+        profile,
         new MeasurementWarning(
           heartbeatStartId,
           warningStartedAt,
@@ -151,7 +154,7 @@ describe('measurements', () => {
     it('should publish a notification when finishing the warning', async () => {
       repositoryMock.findActiveWarning.mockResolvedValueOnce(new MeasurementWarning(randomUUID(), new Date()))
 
-      await service.checkCondition(regularHeartbeat)
+      await service.checkCondition(profile, regularHeartbeat)
 
       expect(repositoryMock.findActiveWarning).toHaveBeenCalledTimes(1)
       expect(repositoryMock.finishWarning).toHaveBeenCalledTimes(1)

--- a/src/modules/profiles/domain/entities/profile.domain.ts
+++ b/src/modules/profiles/domain/entities/profile.domain.ts
@@ -1,0 +1,10 @@
+export class Profile {
+  constructor(
+    private name: string,
+    private id?: string
+  ) {}
+
+  public getName(): string {
+    return this.name
+  }
+}

--- a/src/modules/profiles/domain/ports/profiles.repository.ts
+++ b/src/modules/profiles/domain/ports/profiles.repository.ts
@@ -1,0 +1,6 @@
+import { Profile } from '../entities/profile.domain'
+
+export interface IProfilesRepository {
+  getByName(name: string): Promise<Profile | undefined>
+  create(profile: Profile): Promise<void>
+}

--- a/src/modules/profiles/domain/ports/profiles.service.ts
+++ b/src/modules/profiles/domain/ports/profiles.service.ts
@@ -1,0 +1,6 @@
+import { Profile } from '../entities/profile.domain'
+
+export interface IProfilesService {
+  getByName(name: string): Promise<Profile | undefined>
+  create(profile: Profile): Promise<void>
+}

--- a/src/modules/profiles/domain/services/profiles.ts
+++ b/src/modules/profiles/domain/services/profiles.ts
@@ -1,0 +1,20 @@
+import { Profile } from '../entities/profile.domain'
+import { IProfilesRepository } from '../ports/profiles.repository'
+import { IProfilesService } from '../ports/profiles.service'
+
+export class ProfilesService implements IProfilesService {
+  constructor(
+    private readonly repository: IProfilesRepository
+  ) {}
+
+  public getByName(name: string): Promise<Profile | undefined> {
+    return this.repository.getByName(name)
+  }
+
+  public async create(profile: Profile): Promise<void> {
+    const currentProfile = await this.getByName(profile.getName())
+    if (currentProfile) return
+
+    await this.repository.create(profile)
+  }
+}

--- a/src/modules/profiles/domain/services/tests/profiles.spec.ts
+++ b/src/modules/profiles/domain/services/tests/profiles.spec.ts
@@ -1,0 +1,36 @@
+import { randomUUID } from "crypto"
+import { Profile } from "../../entities/profile.domain"
+import { IProfilesRepository } from "../../ports/profiles.repository"
+import { ProfilesService } from "../profiles"
+
+describe('profiles', () => {
+  class RepositoryMock implements IProfilesRepository {
+    getByName = jest.fn<Promise<Profile | undefined>, [name: string]>()
+    create = jest.fn<Promise<void>, [profile: Profile]>()
+  }
+
+  const repositoryMock = new RepositoryMock()
+  const service = new ProfilesService(repositoryMock)
+
+  afterEach(jest.clearAllMocks)
+
+  describe('create()', () => {
+    it('should not create a new profile if it already exists for the given name', async () => {
+      repositoryMock.getByName.mockResolvedValueOnce(new Profile('testing', randomUUID()))
+
+      await service.create(new Profile('testing'))
+
+      expect(repositoryMock.getByName).toHaveBeenCalledTimes(1)
+      expect(repositoryMock.create).not.toHaveBeenCalled()
+    })
+
+    it('should create a new profile if it does not for the given name yet', async () => {
+      repositoryMock.getByName.mockResolvedValueOnce(undefined)
+
+      await service.create(new Profile('testing'))
+
+      expect(repositoryMock.getByName).toHaveBeenCalledTimes(1)
+      expect(repositoryMock.create).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
Creates the profile domain to be able to correlate the measurements and notifications with a specific profile.

It also adds a workflow to execute the tests whenever a new code is pushed to the repo.